### PR TITLE
Fix windows cmd execution quirk that removes quotes around a given line

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -13,6 +13,8 @@ on:
       - "scripts/bundle_uhdr_for_plugin.sh"
       - "scripts/bundle_uhdr_for_plugin_windows.ps1"
       - "scripts/run_uhdr_test.sh"
+      - "scripts/run_uhdr_test.ps1"
+      - "scripts/test_windows_cmd_quote.ps1"
       - "scripts/windows_build_common.ps1"
       - "scripts/setup_windows_build.ps1"
   workflow_dispatch:
@@ -61,6 +63,11 @@ jobs:
       - name: Build, test, and package plugin
         shell: bash
         run: bash scripts/build_plugin.sh all
+
+      - name: Windows cmd quoting regression test
+        if: matrix.id == 'windows-x64'
+        shell: powershell
+        run: .\scripts\test_windows_cmd_quote.ps1
 
       - name: Upload platform artifact
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Each public release is tagged `vX.Y.Z`, where `X.Y.Z` comes from `Info.lua` `maj
 
 ## Unreleased
 
+### Fixed
+
+- Windows export filter: encoding always failed with `uhdr_repack failed (exit 1, raw 1)` because `LrTasks.execute` passes the line to `cmd /c` verbatim and cmd strips the first and last quote when the line starts with a quoted exe path. `runShell` now wraps the whole command in sacrificial outer quotes.
+- Windows export filter: `--inspect` verification (`inspectIsUltraHdr`) ran a relative `uhdr_repack.exe` via `io.popen` from Lightroom's working directory, so the encoder was never found; it now resolves the bundled absolute path and uses the same sacrificial-quote wrapping.
+- Windows quoting regression test invoked cmd via `Start-Process`, which re-quotes the argument string and masked the bug; it now passes the command line to `cmd.exe /c` verbatim like `LrTasks.execute`, asserts the unwrapped pattern fails, and checks `--inspect` output. The test now runs in the Windows release CI job (it previously existed only as a manual script).
+
 ## v2.0.3
 
 ### Fixed

--- a/ExportHDR.lrplugin/Command.lua
+++ b/ExportHDR.lrplugin/Command.lua
@@ -225,6 +225,15 @@ function CMD.resolveWindowsCommand(line)
 	return line
 end
 
+--- When `cmd /c "<line>"` is run, the first and last quotes are removed
+--- So `cmd /c "test1.exe"` gets converted to `cmd /c test1.exe` which still works.
+--- But when chaining commands like `cmd /c "test1.exe" "test2.exe"`
+--- they get converted to `cmd /c test1.exe" "test2.exe` and fails.
+--- Here we add a pair of extra quotes at beginning and end
+function CMD.wrapForWindowsShell(line)
+	return '"' .. line .. '"'
+end
+
 local function appendCaptureToLog(logPath, capturePath)
 	if not logPath or logPath == "" or not capturePath then
 		return
@@ -266,7 +275,7 @@ function CMD.runShell(line, logPath)
 		if logPath and logPath ~= "" then
 			inner = inner .. " > " .. CMD.shellQuote(capturePath) .. " 2>&1"
 		end
-		local st = LrTasks.execute(inner)
+		local st = LrTasks.execute(CMD.wrapForWindowsShell(inner))
 		if logPath and logPath ~= "" then
 			appendCaptureToLog(logPath, capturePath)
 		end

--- a/ExportHDR.lrplugin/ExportHDRFilterProvider.lua
+++ b/ExportHDR.lrplugin/ExportHDRFilterProvider.lua
@@ -397,7 +397,9 @@ local function inspectIsUltraHdr(binary, path)
 	end
 	local cmd = CMD.buildInspectCommand(binary, path)
 	if CMD.isWindows() then
-		cmd = cmd .. " 2>nul"
+		-- io.popen also goes through `cmd /c`; resolve the relative exe name to the
+		-- absolute bundled path and add sacrificial quotes (see CMD.wrapForWindowsShell).
+		cmd = CMD.wrapForWindowsShell(CMD.resolveWindowsCommand(cmd) .. " 2>nul")
 	else
 		cmd = cmd .. " 2>/dev/null"
 	end
@@ -874,7 +876,10 @@ function ExportHDRFilterProvider.postProcessRenderedPhotos(functionContext, filt
 
 		Log.append(logPath, "Command: " .. cmdLine .. "\n")
 		if CMD.isWindows() then
-			Log.append(logPath, "Execute: " .. CMD.resolveWindowsCommand(cmdLine) .. "\n")
+			Log.append(
+				logPath,
+				"Execute: " .. CMD.wrapForWindowsShell(CMD.resolveWindowsCommand(cmdLine)) .. "\n"
+			)
 		end
 		local st = CMD.runShell(cmdLine, logPath)
 		if st ~= 0 then

--- a/scripts/test_windows_cmd_quote.ps1
+++ b/scripts/test_windows_cmd_quote.ps1
@@ -39,13 +39,28 @@ function Invoke-CmdCapture {
 	if (Test-Path -LiteralPath $CapturePath) {
 		Remove-Item -LiteralPath $CapturePath -Force
 	}
-	# Lightroom LrTasks.execute: one cmd.exe /c layer (system()), not nested cmd /c.
-	$proc = Start-Process -FilePath "cmd.exe" -ArgumentList "/c", $CommandLine -Wait -PassThru -NoNewWindow
+	# Lightroom LrTasks.execute: C runtime system() runs `cmd.exe /c <line>` with the
+	# line appended VERBATIM. Start-Process re-quotes arguments containing spaces,
+	# which silently adds the sacrificial quotes cmd needs — masking quoting bugs —
+	# so build the raw argument string ourselves.
+	$psi = New-Object System.Diagnostics.ProcessStartInfo
+	$psi.FileName = $env:ComSpec
+	$psi.Arguments = "/c " + $CommandLine
+	$psi.UseShellExecute = $false
+	$proc = [System.Diagnostics.Process]::Start($psi)
+	$proc.WaitForExit()
 	$capture = ""
 	if (Test-Path -LiteralPath $CapturePath) {
 		$capture = Get-Content -LiteralPath $CapturePath -Raw -ErrorAction SilentlyContinue
 	}
 	return @{ ExitCode = $proc.ExitCode; Capture = $capture }
+}
+
+function Invoke-LuaWrapForWindowsShell {
+	param([string]$Line)
+	# Mirrors Command.lua CMD.wrapForWindowsShell: sacrificial outer quotes so cmd's
+	# first/last-quote stripping leaves the real command intact.
+	return '"' + $Line + '"'
 }
 
 $Bin = Get-UhdrBinary
@@ -97,10 +112,21 @@ try {
 	Write-Host '==> Staged plug-in bin under path with (2):'
 	Write-Host "    $pluginBin"
 
-	# Current plug-in behavior: full quoted exe path, single shell layer.
 	$resolved = (Invoke-LuaShellQuote $stagedExe) + " " + $argsTail + $redirect
-	Write-Host "==> Execute (resolved): $resolved"
-	$ok = Invoke-CmdCapture -CommandLine $resolved -CapturePath $capturePath
+
+	# Regression guard (v2.0.3 bug): a line that STARTS with a quoted exe path gets its
+	# first and last quote stripped by cmd /c and must fail without running the encoder.
+	Write-Host "==> Unwrapped quoted-exe line (v2.0.3 behavior): expect failure"
+	$unwrapped = Invoke-CmdCapture -CommandLine $resolved -CapturePath $capturePath
+	if ($unwrapped.ExitCode -eq 0 -or ($unwrapped.Capture -match "dimensions:")) {
+		throw "FAIL: unwrapped quoted-exe line unexpectedly succeeded; regression guard is stale."
+	}
+	Write-Host "OK: unwrapped line fails as expected (documents why runShell wraps the command)."
+
+	# Current plug-in behavior: full quoted exe path wrapped in sacrificial outer quotes.
+	$wrapped = Invoke-LuaWrapForWindowsShell $resolved
+	Write-Host "==> Execute (wrapped): $wrapped"
+	$ok = Invoke-CmdCapture -CommandLine $wrapped -CapturePath $capturePath
 	if ($ok.Capture) { Write-Host $ok.Capture }
 
 	if ($ok.Capture -match "internal or external command") {
@@ -112,10 +138,20 @@ try {
 	if (-not (Test-Path -LiteralPath $encodeOut)) {
 		throw "FAIL: staged output JPEG missing: $encodeOut"
 	}
-	if ($ok.Capture -notmatch "dimensions:") {
-		throw ("FAIL: encoder output missing expected dimensions line." + [Environment]::NewLine + $ok.Capture)
+	if ($ok.Capture -notmatch "Wrote ") {
+		throw ("FAIL: encoder output missing expected 'Wrote' line." + [Environment]::NewLine + $ok.Capture)
 	}
-	Write-Host "OK: full-path invocation works with plug-in path containing space and (2)."
+	Write-Host "OK: wrapped full-path invocation works with plug-in path containing space and (2)."
+
+	# Mirror inspectIsUltraHdr: wrapped `--inspect` via the same shell layer must
+	# report Ultra HDR for the staged output.
+	$inspectCapture = Join-Path $workDir "uhdr_inspect_capture.txt"
+	$inspectLine = (Invoke-LuaShellQuote $stagedExe) + " --inspect " + (Invoke-LuaShellQuote $encodeOut) + " > " + (Invoke-LuaShellQuote $inspectCapture) + " 2>&1"
+	$inspect = Invoke-CmdCapture -CommandLine (Invoke-LuaWrapForWindowsShell $inspectLine) -CapturePath $inspectCapture
+	if ($inspect.Capture -notmatch "is_ultra_hdr: yes") {
+		throw ("FAIL: wrapped --inspect did not report is_ultra_hdr: yes." + [Environment]::NewLine + $inspect.Capture)
+	}
+	Write-Host "OK: wrapped --inspect reports is_ultra_hdr: yes on staged output."
 
 	# Legacy v2.0.1 pattern: cmd /c cd /d ... && relative exe (should fail without encoder output).
 	$legacyCapturePath = Join-Path $workDir "uhdr_run_legacy_capture.txt"


### PR DESCRIPTION
Hello there! First of all, awesome plugin. These past days I was struggling to upload my photos as hdr on instagram, and had written a script using libultrahdr to no avail. So this plugin was a blessing. 

Unfortunately I was getting an error on windows that prevented it from running the last command step. The issue was that `LrTasks.execute` sends the line exactly as is to `cmd /c`, and `cmd /c` has an odd quirk that by design removes the first and last quotes (if present) from the given line. 

So for example the line `"one.exe"` gets converted to `one.exe`,  but  `"one.exe" "two.exe"` will wrongly be converted to  `one.exe" "two.exe` and fail.

As a fix I added an extra quote at beginning and end to prevent malformed lines. So instead of `LrTasks.execute(inner)` now we have `LrTasks.execute(CMD.wrapForWindowsShell(inner))`

I used claude fable to analyze the repo and aditionally it wrote a few tests for it, and I realized that `test_windows_cmd_quote.ps1` wasn't hooked into the Windows CI, so I added that as well to the release-plugin.yml. 

Let me know if you would like any changes or iterate on the tests. I'm already using this version so I can confirm that everything works.

Cheers!

