### PR TITLE
Release v2.0.5: fix macOS paths with spaces (issue #2)

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/bundle_uhdr_for_plugin_windows.ps1"
       - "scripts/run_uhdr_test.sh"
       - "scripts/run_uhdr_test.ps1"
+      - "scripts/test_macos_shell_quote.sh"
       - "scripts/test_windows_cmd_quote.ps1"
       - "scripts/windows_build_common.ps1"
       - "scripts/setup_windows_build.ps1"
@@ -63,6 +64,11 @@ jobs:
       - name: Build, test, and package plugin
         shell: bash
         run: bash scripts/build_plugin.sh all
+
+      - name: macOS shell quoting regression test
+        if: matrix.id == 'macos-arm64'
+        shell: bash
+        run: bash scripts/test_macos_shell_quote.sh
 
       - name: Windows cmd quoting regression test
         if: matrix.id == 'windows-x64'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Each public release is tagged `vX.Y.Z`, where `X.Y.Z` comes from `Info.lua` `maj
 
 ## Unreleased
 
+## v2.0.5
+
+### Fixed
+
+- macOS export filter: quote the bundled `uhdr_repack` path in `CMD.shellBinary` so installs under `~/Library/Application Support/Adobe/Lightroom/Modules` (and other paths with spaces) no longer fail with `sh: …/Application: No such file or directory` (issue #2).
+- Add `scripts/test_macos_shell_quote.sh` regression test (unquoted path fails; `shellQuote` encode/`--inspect` succeeds) and run it in the macOS release CI job.
+
 ## v2.0.4
 
 ### Fixed

--- a/ExportHDR.lrplugin/Command.lua
+++ b/ExportHDR.lrplugin/Command.lua
@@ -65,7 +65,8 @@ function CMD.shellBinary(binary)
 	if CMD.isWindows() then
 		return CMD.binaryFileName()
 	end
-	return binary or CMD.bundledBinaryPath()
+	-- Quote so installs under paths with spaces (e.g. Application Support) work.
+	return CMD.shellQuote(binary or CMD.bundledBinaryPath())
 end
 
 --- Build main encode command string (returns full line for LrTasks.execute).

--- a/ExportHDR.lrplugin/Info.lua
+++ b/ExportHDR.lrplugin/Info.lua
@@ -8,7 +8,7 @@ return {
 	LrSdkMinimumVersion = 14.0,
 	LrToolkitIdentifier = "com.karachungen.lightroom.export.ultrahdr",
 	LrPluginName = "Ultra HDR Export",
-	VERSION = { major = 2, minor = 0, revision = 4, build = 0 },
+	VERSION = { major = 2, minor = 0, revision = 5, build = 0 },
 
 	LrExportFilterProvider = {
 		{

--- a/scripts/test_macos_shell_quote.sh
+++ b/scripts/test_macos_shell_quote.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# Regression test: POSIX shell invocation for plug-in paths with whitespace
+# (e.g. macOS ~/Library/Application Support/Adobe/Lightroom/Modules).
+# Mirrors ExportHDR.lrplugin/Command.lua shellBinary + shellQuote on non-Windows.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST_DIR="$REPO_ROOT/test"
+HDR="$TEST_DIR/hdr-raw.tif"
+BASE="$TEST_DIR/sdr.jpg"
+COMMAND_LUA="$REPO_ROOT/ExportHDR.lrplugin/Command.lua"
+
+# Mirror CMD.shellQuote for POSIX (single-quote with '\'' escaping).
+lua_shell_quote() {
+	local path="$1"
+	if [[ -z "$path" ]]; then
+		echo "''"
+		return
+	fi
+	local escaped="${path//\'/\'\\\'\'}"
+	printf "'%s'" "$escaped"
+}
+
+find_uhdr_binary() {
+	local candidates=(
+		"$REPO_ROOT/ExportHDR.lrplugin/bin/uhdr_repack"
+		"$REPO_ROOT/tools/uhdr_repack/build/uhdr_repack"
+	)
+	local c
+	for c in "${candidates[@]}"; do
+		if [[ -x "$c" ]]; then
+			echo "$c"
+			return 0
+		fi
+	done
+	return 1
+}
+
+binary_runs() {
+	local bin="$1"
+	# Real encoder prints usage on unknown args; wrong-arch binaries fail to exec.
+	local out
+	out="$("$bin" --not-a-real-flag 2>&1 || true)"
+	if echo "$out" | grep -qiE 'exec format|cannot execute|bad CPU|wrong architecture'; then
+		return 1
+	fi
+	if echo "$out" | grep -qE 'uhdr_repack|Usage:|unknown argument'; then
+		return 0
+	fi
+	return 1
+}
+
+install_quote_stub() {
+	# Used only when the host cannot execute the real (macOS) encoder — still
+	# validates shell word-splitting under Application Support paths.
+	local dest="$1"
+	cat >"$dest" <<'STUB'
+#!/bin/sh
+set -eu
+inspect=0
+hdr=""
+base=""
+out=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+	--inspect) inspect=1; shift; jpeg="$1"; shift ;;
+	--hdr-tiff) shift; hdr="$1"; shift ;;
+	--base) shift; base="$1"; shift ;;
+	--out) shift; out="$1"; shift ;;
+	*) shift ;;
+	esac
+done
+if [ "$inspect" -eq 1 ]; then
+	echo "is_ultra_hdr: yes"
+	echo "dimensions: 1x1"
+	echo "gainmap_size: 1x1"
+	echo "markers: primary_xmp=yes"
+	exit 0
+fi
+if [ -z "$base" ] || [ -z "$out" ]; then
+	echo "stub: missing --base/--out" >&2
+	exit 2
+fi
+cp "$base" "$out"
+echo "Wrote $out"
+echo "dimensions: 1x1"
+exit 0
+STUB
+	chmod +x "$dest"
+}
+
+if [[ ! -f "$HDR" ]] || [[ ! -f "$BASE" ]]; then
+	echo "Missing test inputs. See test/README.md — need:" >&2
+	echo "  $HDR" >&2
+	echo "  $BASE" >&2
+	exit 3
+fi
+
+if [[ ! -f "$COMMAND_LUA" ]]; then
+	echo "Missing Command.lua: $COMMAND_LUA" >&2
+	exit 2
+fi
+
+STAGING_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/uhdr_Application Support_XXXXXX")"
+PLUGIN_BIN="$STAGING_ROOT/ExportHDR.lrplugin/bin"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/uhdr_macos_quote_work_XXXXXX")"
+cleanup() {
+	rm -rf "$STAGING_ROOT" "$WORKDIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$PLUGIN_BIN"
+STAGED_BIN="$PLUGIN_BIN/uhdr_repack"
+USED_STUB=0
+
+if REAL_BIN="$(find_uhdr_binary)" && binary_runs "$REAL_BIN"; then
+	cp "$REAL_BIN" "$STAGED_BIN"
+	# Bundle colocated dylibs when present (real macOS plugin layout).
+	REAL_DIR="$(dirname "$REAL_BIN")"
+	shopt -s nullglob
+	for dylib in "$REAL_DIR"/*.dylib; do
+		cp "$dylib" "$PLUGIN_BIN/"
+	done
+	shopt -u nullglob
+	echo "==> Using real encoder: $REAL_BIN"
+else
+	install_quote_stub "$STAGED_BIN"
+	USED_STUB=1
+	echo "==> No runnable uhdr_repack on this host; using quoting stub at:"
+	echo "    $STAGED_BIN"
+fi
+
+ENCODE_HDR="$WORKDIR/uhdr_hdr_encode.tif"
+ENCODE_BASE="$WORKDIR/uhdr_sdr_base_copy.jpg"
+ENCODE_OUT="$WORKDIR/uhdr_out_encode.jpg"
+cp "$HDR" "$ENCODE_HDR"
+cp "$BASE" "$ENCODE_BASE"
+
+ARGS_TAIL=$(
+	printf '%s ' \
+		"--hdr-tiff" "$(lua_shell_quote "$ENCODE_HDR")" \
+		"--base" "$(lua_shell_quote "$ENCODE_BASE")" \
+		"--out" "$(lua_shell_quote "$ENCODE_OUT")" \
+		"--base-quality" "92" \
+		"--gainmap-quality" "85" \
+		"--gainmap-scale" "1" \
+		"--min-content-boost" "1" \
+		"--max-content-boost" "1000" \
+		"--target-display-peak" "1000"
+)
+
+echo "==> Staged plug-in bin under Application Support path:"
+echo "    $PLUGIN_BIN"
+
+# Bug repro (issue #2): unquoted absolute path is word-split by sh.
+echo "==> Unquoted binary path (pre-fix shellBinary): expect failure"
+UNQUOTED_ERR="$(mktemp "$WORKDIR/unquoted_err.XXXXXX")"
+set +e
+sh -c "$STAGED_BIN $ARGS_TAIL" >"$WORKDIR/unquoted_out.txt" 2>"$UNQUOTED_ERR"
+UNQUOTED_STATUS=$?
+set -e
+UNQUOTED_MSG="$(cat "$UNQUOTED_ERR")"
+echo "$UNQUOTED_MSG"
+
+if [[ -f "$ENCODE_OUT" ]]; then
+	echo "FAIL: unquoted path unexpectedly produced output: $ENCODE_OUT" >&2
+	exit 1
+fi
+# macOS/bash: "No such file or directory"; Debian dash: "not found"
+if ! echo "$UNQUOTED_MSG" | grep -qiE 'No such file or directory|not found'; then
+	echo "FAIL: expected shell missing-file error from unquoted path." >&2
+	exit 1
+fi
+# sh reports the truncated token ending at the space (…/Application).
+if ! echo "$UNQUOTED_MSG" | grep -Fq "Application"; then
+	echo "FAIL: expected shell to split on 'Application Support' space." >&2
+	exit 1
+fi
+echo "OK: unquoted path fails as expected (issue #2)."
+
+# Fixed behavior: CMD.shellQuote around the binary path.
+QUOTED_BIN="$(lua_shell_quote "$STAGED_BIN")"
+CAPTURE="$WORKDIR/uhdr_run_capture.txt"
+echo "==> Quoted binary path (shellQuote): $QUOTED_BIN"
+set +e
+sh -c "$QUOTED_BIN $ARGS_TAIL" >"$CAPTURE" 2>&1
+QUOTED_STATUS=$?
+set -e
+if [[ -s "$CAPTURE" ]]; then
+	cat "$CAPTURE"
+fi
+
+if [[ "$QUOTED_STATUS" -ne 0 ]]; then
+	echo "FAIL: quoted uhdr_repack exited $QUOTED_STATUS (expected 0)." >&2
+	exit 1
+fi
+if [[ ! -f "$ENCODE_OUT" ]]; then
+	echo "FAIL: staged output JPEG missing: $ENCODE_OUT" >&2
+	exit 1
+fi
+if ! grep -q "Wrote " "$CAPTURE"; then
+	echo "FAIL: encoder output missing expected 'Wrote' line." >&2
+	exit 1
+fi
+echo "OK: shellQuote'd binary path works under Application Support."
+
+INSPECT_CAPTURE="$WORKDIR/uhdr_inspect_capture.txt"
+set +e
+sh -c "$QUOTED_BIN --inspect $(lua_shell_quote "$ENCODE_OUT")" >"$INSPECT_CAPTURE" 2>&1
+INSPECT_STATUS=$?
+set -e
+if [[ -s "$INSPECT_CAPTURE" ]]; then
+	cat "$INSPECT_CAPTURE"
+fi
+if [[ "$INSPECT_STATUS" -ne 0 ]]; then
+	echo "FAIL: quoted --inspect exited $INSPECT_STATUS." >&2
+	exit 1
+fi
+if ! grep -q "is_ultra_hdr: yes" "$INSPECT_CAPTURE"; then
+	echo "FAIL: quoted --inspect did not report is_ultra_hdr: yes." >&2
+	exit 1
+fi
+echo "OK: quoted --inspect reports is_ultra_hdr: yes."
+
+# Regression guard: plugin must shellQuote the macOS binary token (issue #2 fix).
+echo "==> Assert Command.lua shellBinary quotes the macOS binary path"
+if ! awk '
+	BEGIN { in_fn = 0 }
+	/^function CMD\.shellBinary\(binary\)/ { in_fn = 1; next }
+	in_fn && /^end$/ {
+		if (!found) { exit 2 }
+		exit 0
+	}
+	in_fn && /return CMD\.shellQuote\(binary or CMD\.bundledBinaryPath\(\)\)/ { found = 1 }
+' "$COMMAND_LUA"; then
+	echo "FAIL: CMD.shellBinary does not return CMD.shellQuote(binary or CMD.bundledBinaryPath())." >&2
+	echo "      macOS installs under Application Support still break (issue #2)." >&2
+	exit 1
+fi
+echo "OK: Command.lua shellBinary uses shellQuote on macOS."
+
+if [[ "$USED_STUB" -eq 1 ]]; then
+	echo "NOTE: quoting stub was used; run on macOS after build_plugin.sh for a real encode."
+fi
+
+exit 0

--- a/test/README.md
+++ b/test/README.md
@@ -16,6 +16,8 @@ The smoke scripts include a Cyrillic folder path test (`test/тест/`). Lightr
 
 **Windows cmd quoting:** `.\scripts\test_windows_cmd_quote.ps1` verifies full-path shell invocation under a synthetic path containing space and `(N)`, and asserts the legacy `cd` + relative-exe pattern fails.
 
+**macOS shell quoting:** `./scripts/test_macos_shell_quote.sh` stages the encoder under a path containing `Application Support`, asserts an unquoted binary path fails (issue #2), and asserts `CMD.shellQuote` + `Command.lua` `shellBinary` quoting succeed for encode/`--inspect`.
+
 If these files are missing, the script exits with a clear message.
 
 **Unicode paths:** the smoke scripts also encode to `test/тест/out_uhdr.jpg` (Cyrillic folder name, normal output filename) to verify UTF-8 path handling on Windows and macOS. Inputs stay ASCII (`hdr-raw.tif`, `sdr.jpg`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#2](https://github.com/karachungen/lightroom-plugin-export-hdr/issues/2): macOS plugin installs under `~/Library/Application Support/...` failed because `CMD.shellBinary` left the bundled `uhdr_repack` path unquoted, so `sh` split on the space (`sh: …/Application: No such file or directory`).

## Changes

- Quote the macOS binary path in `CMD.shellBinary` via `CMD.shellQuote` (same approach as the issue author’s patch).
- Add `scripts/test_macos_shell_quote.sh`: stages under an `Application Support` path, asserts unquoted fails, asserts quoted encode/`--inspect` succeeds, and asserts `Command.lua` uses `shellQuote`.
- Wire the test into the macOS release CI job.
- Bump to **v2.0.5** with changelog.

## Test plan

- [x] Ran `./scripts/test_macos_shell_quote.sh` **before** the fix → failed on missing `shellQuote` in `shellBinary` (and unquoted path split on `Application`).
- [x] Applied fix and re-ran → passed.
- [x] `./scripts/build_release_notes.sh --check-only` → OK for v2.0.5.
- [ ] macOS CI runs real encode under the quoting regression test after merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d4cad36-8c70-4020-b5f1-42f937df2792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d4cad36-8c70-4020-b5f1-42f937df2792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

