### PR TITLE
Release v2.0.6: static uhdr_repack binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Each public release is tagged `vX.Y.Z`, where `X.Y.Z` comes from `Info.lua` `maj
 
 ## Unreleased
 
+## v2.0.6
+
+### Changed
+
+- Ship a single self-contained `uhdr_repack` binary on macOS and Windows: libultrahdr and libjpeg-turbo are linked statically, so downloads no longer include separate `.dylib` / `.dll` files that Gatekeeper can block one-by-one (closes #3).
+
+### Removed
+
+- macOS local-build requirement for Homebrew `jpeg-turbo` and `dylibbundler` (jpeg is vendored via `UHDR_BUILD_DEPS`).
+
 ## v2.0.5
 
 ### Fixed

--- a/ExportHDR.lrplugin/Info.lua
+++ b/ExportHDR.lrplugin/Info.lua
@@ -8,7 +8,7 @@ return {
 	LrSdkMinimumVersion = 14.0,
 	LrToolkitIdentifier = "com.karachungen.lightroom.export.ultrahdr",
 	LrPluginName = "Ultra HDR Export",
-	VERSION = { major = 2, minor = 0, revision = 5, build = 0 },
+	VERSION = { major = 2, minor = 0, revision = 6, build = 0 },
 
 	LrExportFilterProvider = {
 		{

--- a/ExportHDR.lrplugin/bin/README.txt
+++ b/ExportHDR.lrplugin/bin/README.txt
@@ -13,19 +13,19 @@ After cloning the repo, this folder is empty of binaries until you build for you
     .\scripts\bundle_uhdr_for_plugin_windows.ps1
 
 The build scripts use CMake presets (tools/uhdr_repack/CMakePresets.json) — the same
-logic as GitHub Actions. They build google/libultrahdr (vendored via FetchContent) inside
-tools/uhdr_repack/build, copy the encoder here, and bundle runtime libraries next to
-the binary:
+logic as GitHub Actions. They build google/libultrahdr and libjpeg-turbo (both vendored
+via FetchContent, both linked statically) inside tools/uhdr_repack/build, then copy the
+single self-contained encoder here:
 
-  macOS:  bin/uhdr_repack + *.dylib
-  Windows: bin/uhdr_repack.exe + *.dll
+  macOS:  bin/uhdr_repack
+  Windows: bin/uhdr_repack.exe
 
 GitHub Releases ship separate archives (no mixed OS binaries in one zip):
   ExportHDR.lrplugin-macos-arm64.zip
   ExportHDR.lrplugin-windows-x64.zip
 
-macOS requires: Xcode CLT, CMake, libjpeg-turbo (e.g. Homebrew: jpeg-turbo).
-Optional on macOS: brew install dylibbundler (otherwise an otool-based fallback copies deps).
+macOS requires: Xcode CLT, CMake. uhdr_repack links libuhdr and libjpeg-turbo statically,
+so nothing else needs to be installed or bundled at runtime.
 
 Windows requires: Git, CMake 3.31.x, Ninja, and MSVC (Visual Studio 2022 Build Tools, x64).
 One-time setup from repo root:
@@ -37,10 +37,10 @@ One-time setup from repo root:
   .\scripts\build_plugin.ps1 all
 
 libjpeg-turbo is built automatically via libultrahdr (UHDR_BUILD_DEPS) during configure.
-CMake 4.x currently breaks vendored libjpeg-turbo 3.0.1; pin CMake 3.31.x on Windows.
+CMake 4.x rejects vendored libjpeg-turbo 3.0.1's old cmake_minimum_required(); build_plugin.sh
+works around this on both platforms by exporting CMAKE_POLICY_VERSION_MINIMUM=3.5. The
+Windows CMake 3.31.x pin above predates that workaround and has not been re-verified against
+CMake 4.x — treat it as still required until someone confirms otherwise on Windows.
 
 Optional override: UHDR_USE_SYSTEM=1 to link against a preinstalled libultrahdr
 (and UHDR_ROOT=... if CMake cannot find headers/libs).
-
-macOS only: if ./uhdr_repack exits immediately with "killed", re-run the build
-(it ad-hoc re-signs after rewriting library paths).

--- a/scripts/build_plugin.ps1
+++ b/scripts/build_plugin.ps1
@@ -65,24 +65,6 @@ function Invoke-BundleWindows {
 	Clear-PluginBin
 	Copy-Item -LiteralPath $buildExe -Destination (Join-Path $PluginBin "uhdr_repack.exe") -Force
 
-	$dllRoots = @(
-		$BuildDir,
-		(Join-Path $BuildDir "Release"),
-		(Join-Path $BuildDir "_deps\libultrahdr-build"),
-		(Join-Path $BuildDir "_deps\libultrahdr-build\Release")
-	)
-	$copied = @{}
-	foreach ($root in $dllRoots) {
-		if (-not (Test-Path -LiteralPath $root)) { continue }
-		Get-ChildItem -LiteralPath $root -Filter "*.dll" -File -ErrorAction SilentlyContinue | ForEach-Object {
-			if (-not $copied.ContainsKey($_.Name)) {
-				Copy-Item -LiteralPath $_.FullName -Destination (Join-Path $PluginBin $_.Name) -Force
-				$copied[$_.Name] = $true
-				Write-Host "    bundled $($_.Name)"
-			}
-		}
-	}
-
 	$pluginExe = Join-Path $PluginBin "uhdr_repack.exe"
 	Write-Host "==> Smoke: uhdr_repack.exe (usage if no args)"
 	$prevEap = $ErrorActionPreference

--- a/scripts/build_plugin.sh
+++ b/scripts/build_plugin.sh
@@ -136,7 +136,7 @@ cmd_install_deps() {
 			echo "Homebrew is required. See https://brew.sh" >&2
 			exit 1
 		fi
-		brew install cmake jpeg-turbo dylibbundler
+		brew install cmake
 		;;
 	MINGW* | MSYS* | CYGWIN* | Windows_NT)
 		if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
@@ -159,6 +159,10 @@ cmd_build() {
 		echo "==> Cleaning $BUILD_DIR"
 		rm -rf "$BUILD_DIR"
 	fi
+
+	# Vendored libjpeg-turbo's cmake_minimum_required() predates CMake 4's removal of
+	# compatibility with CMake < 3.5; this tells CMake to treat it as 3.5 instead of erroring.
+	export CMAKE_POLICY_VERSION_MINIMUM=3.5
 
 	echo "==> Configuring preset: $PRESET"
 	if [[ ${#cmake_extra[@]} -gt 0 ]]; then
@@ -220,92 +224,10 @@ bundle_macos() {
 	cp "$build_exe" "$PLUGIN_BIN/uhdr_repack"
 	chmod +x "$PLUGIN_BIN/uhdr_repack"
 
-	local libuhdr_build="$BUILD_DIR/_deps/libultrahdr-build"
-	if [[ -d "$libuhdr_build" ]]; then
-		shopt -s nullglob
-		local f
-		for f in "$libuhdr_build"/libuhdr*.dylib; do
-			cp -f "$f" "$PLUGIN_BIN/"
-		done
-		shopt -u nullglob
-		local uhdr_bin="$PLUGIN_BIN/uhdr_repack"
-		local dep
-		while IFS= read -r dep; do
-			[[ -n "$dep" ]] || continue
-			case "$dep" in
-			@rpath/libuhdr*.dylib)
-				local base="${dep##*/}"
-				install_name_tool -change "$dep" "@loader_path/$base" "$uhdr_bin" 2>/dev/null || true
-				;;
-			esac
-		done < <(otool -L "$uhdr_bin" | tail -n +2 | awk '{print $1}')
-	fi
-
-	bundle_with_dylibbundler() {
-		if ! command -v dylibbundler &>/dev/null; then
-			return 1
-		fi
-		echo "==> Bundling dependencies with dylibbundler"
-		(
-			cd "$PLUGIN_BIN"
-			dylibbundler -od -b -x "./uhdr_repack" -d . -p "@loader_path/"
-		)
-	}
-
-	bundle_fallback() {
-		local dir="$PLUGIN_BIN"
-		local max=6 round
-		echo "==> Bundling dependencies (otool fallback; install dylibbundler for best results)"
-		for ((round = 1; round <= max; round++)); do
-			local changed=0
-			local bins=("$dir/uhdr_repack")
-			while IFS= read -r -d '' f; do
-				bins+=("$f")
-			done < <(find "$dir" -maxdepth 1 -name "*.dylib" -print0 2>/dev/null || true)
-			local bin dep name dest
-			for bin in "${bins[@]}"; do
-				[[ -f "$bin" ]] || continue
-				chmod u+w "$bin" || true
-				while IFS= read -r dep; do
-					[[ -n "$dep" ]] || continue
-					case "$dep" in
-					@*) continue ;;
-					/usr/lib/* | /System/*) continue ;;
-					*/libSystem*) continue ;;
-					esac
-					[[ ! -f "$dep" ]] && continue
-					[[ "$dep" == *.framework/* ]] && continue
-					name="$(basename "$dep")"
-					[[ "$name" == *.dylib ]] || continue
-					dest="$dir/$name"
-					if [[ ! -f "$dest" ]]; then
-						echo "    copy $dep"
-						cp -f "$dep" "$dest"
-						chmod u+w "$dest"
-						changed=1
-					fi
-					install_name_tool -change "$dep" "@loader_path/$name" "$bin" 2>/dev/null || true
-				done < <(otool -L "$bin" | tail -n +2 | awk '{ print $1 }')
-			done
-			[[ $changed -eq 0 ]] && break
-		done
-	}
-
-	if bundle_with_dylibbundler; then
-		:
-	else
-		bundle_fallback
-	fi
-
-	echo "==> Ad-hoc codesign (required after rewriting load commands)"
-	local f
-	for f in "$PLUGIN_BIN"/*.dylib; do
-		[[ -f "$f" ]] || continue
-		codesign --force --sign - "$f"
-	done
-	if [[ -f "$PLUGIN_BIN/uhdr_repack" ]]; then
-		codesign --force --sign - "$PLUGIN_BIN/uhdr_repack"
-	fi
+	# uhdr_repack links libuhdr and libjpeg-turbo statically (see tools/uhdr_repack/CMakeLists.txt),
+	# so the only remaining dependencies are Apple system frameworks/libraries — no bundling needed.
+	echo "==> Ad-hoc codesign (required after copying into the plug-in bundle)"
+	codesign --force --sign - "$PLUGIN_BIN/uhdr_repack"
 
 	echo "==> Bundled encoder: $PLUGIN_BIN/uhdr_repack"
 }
@@ -320,26 +242,6 @@ bundle_windows() {
 	echo "==> Cleaning old Windows bundle in $PLUGIN_BIN"
 	clean_plugin_bin
 	cp "$build_exe" "$PLUGIN_BIN/uhdr_repack.exe"
-
-	local roots=(
-		"$BUILD_DIR"
-		"$BUILD_DIR/Release"
-		"$BUILD_DIR/_deps/libultrahdr-build"
-		"$BUILD_DIR/_deps/libultrahdr-build/Release"
-	)
-	local root dll name
-	for root in "${roots[@]}"; do
-		[[ -d "$root" ]] || continue
-		shopt -s nullglob
-		for dll in "$root"/*.dll; do
-			name="$(basename "$dll")"
-			if [[ ! -f "$PLUGIN_BIN/$name" ]]; then
-				cp -f "$dll" "$PLUGIN_BIN/$name"
-				echo "    bundled $name"
-			fi
-		done
-		shopt -u nullglob
-	done
 
 	local plugin_exe="$PLUGIN_BIN/uhdr_repack.exe"
 	echo "==> Smoke: uhdr_repack.exe (usage if no args)"

--- a/tools/uhdr_repack/CMakeLists.txt
+++ b/tools/uhdr_repack/CMakeLists.txt
@@ -67,14 +67,15 @@ else()
     GIT_TAG ${_LIBUHDR_TAG}
     GIT_SHALLOW TRUE
   )
+  set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build libultrahdr as a static library" FORCE)
   set(UHDR_WRITE_XMP ON CACHE BOOL "Write gainmap metadata in XMP packet" FORCE)
   set(UHDR_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
   set(UHDR_BUILD_TESTS OFF CACHE BOOL "" FORCE)
   set(UHDR_BUILD_BENCHMARK OFF CACHE BOOL "" FORCE)
   set(UHDR_BUILD_FUZZERS OFF CACHE BOOL "" FORCE)
-  if(WIN32)
-    set(UHDR_BUILD_DEPS ON CACHE BOOL "Build libjpeg-turbo via libultrahdr on Windows" FORCE)
-  endif()
+  # Vendor + statically build libjpeg-turbo instead of linking whatever the host has installed
+  # (e.g. Homebrew's dylib, which pins an absolute /opt/homebrew or /usr/local path).
+  set(UHDR_BUILD_DEPS ON CACHE BOOL "Build libjpeg-turbo via libultrahdr" FORCE)
   FetchContent_MakeAvailable(libultrahdr)
 endif()
 

--- a/tools/uhdr_repack/README.md
+++ b/tools/uhdr_repack/README.md
@@ -47,7 +47,7 @@ flowchart TB
 
 ## Build
 
-From **`tools/uhdr_repack`**. CMake 3.15+, C++17. macOS also uses Objective-C++. On macOS, libjpeg is provided by the system or Homebrew (**`brew install jpeg-turbo`**). On Windows, libjpeg-turbo is vendored automatically via libultrahdr **`UHDR_BUILD_DEPS`**. Use **CMake 3.15–3.31.x** on Windows (CMake 4.x fails on vendored libjpeg-turbo 3.0.1 until upstream updates; CI pins **3.31.6**). First configure downloads libultrahdr into **`build/_deps/`**.
+From **`tools/uhdr_repack`**. CMake 3.15+, C++17. macOS also uses Objective-C++. libjpeg-turbo is vendored automatically via libultrahdr **`UHDR_BUILD_DEPS`** on both platforms (static link). Use **CMake 3.15–3.31.x** on Windows (CMake 4.x fails on vendored libjpeg-turbo 3.0.1 until upstream updates; CI pins **3.31.6**). First configure downloads libultrahdr into **`build/_deps/`**.
 
 **Canonical configure/build** (shared by local builds and GitHub Actions) — use [CMakePresets.json](CMakePresets.json):
 
@@ -86,7 +86,7 @@ cmake --build --preset macos-arm64-release
 
 Legacy aliases (build + bundle only): `bundle_uhdr_for_plugin.sh` / `bundle_uhdr_for_plugin_windows.ps1`.
 
-Each platform copies only that OS binary and runtime libraries into **`ExportHDR.lrplugin/bin/`**. Plug-in flow: **[../../README.md](../../README.md)**
+Each platform copies only that OS binary into **`ExportHDR.lrplugin/bin/`** (self-contained; no runtime `.dylib` / `.dll`). Plug-in flow: **[../../README.md](../../README.md)**
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Link libultrahdr and libjpeg-turbo **statically** so `bin/` ships a single self-contained `uhdr_repack` / `uhdr_repack.exe` (no colocated `.dylib` / `.dll`).
- Simplifies macOS Gatekeeper friction on downloaded builds (closes #3).
- Drop Homebrew `jpeg-turbo` / `dylibbundler` from macOS install-deps; vendor jpeg via `UHDR_BUILD_DEPS` on both platforms.
- Bump plugin version to **v2.0.6** with CHANGELOG release notes.

## Test plan
- [x] `./scripts/build_plugin.sh all --clean` on macOS
- [x] `otool -L ExportHDR.lrplugin/bin/uhdr_repack` shows only system frameworks
- [x] No `*.dylib` in `ExportHDR.lrplugin/bin/`
- [x] `./scripts/build_release_notes.sh --check-only` for v2.0.6
- [ ] Windows CI job builds single `uhdr_repack.exe` without DLLs
- [ ] GitHub Release `v2.0.6` publishes both platform zips after merge