### PR TITLE
Support for high-resolution images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Each public release is tagged `vX.Y.Z`, where `X.Y.Z` comes from `Info.lua` `maj
 
 ## Unreleased
 
+### Fixed
+
+- Raise the bundled libultrahdr maximum image dimension from 8192 to 65500 pixels, allowing exports of high-resolution images.
+
 ## v2.0.6
 
 ### Changed

--- a/tools/uhdr_repack/CMakeLists.txt
+++ b/tools/uhdr_repack/CMakeLists.txt
@@ -73,6 +73,7 @@ else()
   set(UHDR_BUILD_TESTS OFF CACHE BOOL "" FORCE)
   set(UHDR_BUILD_BENCHMARK OFF CACHE BOOL "" FORCE)
   set(UHDR_BUILD_FUZZERS OFF CACHE BOOL "" FORCE)
+  set(UHDR_MAX_DIMENSION 65500 CACHE STRING "Maximum input width and height supported by libultrahdr" FORCE)
   # Vendor + statically build libjpeg-turbo instead of linking whatever the host has installed
   # (e.g. Homebrew's dylib, which pins an absolute /opt/homebrew or /usr/local path).
   set(UHDR_BUILD_DEPS ON CACHE BOOL "Build libjpeg-turbo via libultrahdr" FORCE)


### PR DESCRIPTION
Raise the bundled libultrahdr maximum image dimension from 8192 to 65500 pixels, allowing exports of high-resolution images.

Problem before with an image of 8256x5504 pixels (RAW file from Nikon Z8):

<img width="303" height="326" alt="Screenshot 2026-09-06 at 17 37 49" src="https://github.com/user-attachments/assets/1743723e-0eb7-4438-989e-b85e5bc38f04" />

And log output:
`encode: uhdr_enc_set_raw_image HDR: image dimensions cannot be larger than 8192x8192, received image dimensions 8256x5504
uhdr_repack exit status: raw=1280 exit≈5
`